### PR TITLE
Remove xpc-connection dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   },
   "optionalDependencies": {
     "bluetooth-hci-socket": "~0.4.0",
-    "bplist-parser": "0.0.6",
-    "xpc-connection": "~0.1.4"
+    "bplist-parser": "0.0.6"
   },
   "devDependencies": {
     "jshint": "latest",


### PR DESCRIPTION
It seems to be only for OS X, which Able doesn’t support.
Removes the warnings during `npm install`:

```
npm WARN optional dep failed, continuing xpc-connection@0.1.4
```
